### PR TITLE
Add priority and due date options to todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ This repository contains a simple command line todo application written in Pytho
 ## Usage
 
 ```
-python todo.py add "Buy milk"      # Add a new task
+python todo.py add "Buy milk" --priority high --due 2024-05-01  # Add a new task
 python todo.py list                 # List all tasks
 python todo.py done 1               # Mark task 1 as done
 python todo.py delete 1             # Delete task 1
 python todo.py clear                # Remove all tasks
 ```
 
-Tasks are stored in `tasks.json` in the same directory.
+The `add` command accepts optional `--priority` and `--due YYYY-MM-DD` arguments to
+specify a priority level and due date for the task. Tasks are stored in
+`tasks.json` in the same directory.

--- a/todo.py
+++ b/todo.py
@@ -18,10 +18,15 @@ def save_tasks(tasks: List[Dict]):
     with open(TASKS_FILE, "w") as f:
         json.dump(tasks, f, indent=2)
 
-def add_task(description: str):
+def add_task(description: str, priority: str = None, due: str = None):
     tasks = load_tasks()
     task_id = max([t["id"] for t in tasks], default=0) + 1
-    tasks.append({"id": task_id, "description": description, "done": False})
+    task = {"id": task_id, "description": description, "done": False}
+    if priority:
+        task["priority"] = priority
+    if due:
+        task["due"] = due
+    tasks.append(task)
     save_tasks(tasks)
     print(f"Added task {task_id}: {description}")
 
@@ -30,9 +35,26 @@ def list_tasks():
     if not tasks:
         print("No tasks found.")
         return
+
+    show_priority = any("priority" in t for t in tasks)
+    show_due = any("due" in t for t in tasks)
+
+    header_parts = ["ID", "Status"]
+    if show_priority:
+        header_parts.append("Priority")
+    if show_due:
+        header_parts.append("Due")
+    header_parts.append("Description")
+    print(" ".join(header_parts))
+
     for t in tasks:
-        status = "[x]" if t.get("done") else "[ ]"
-        print(f"{t['id']} {status} {t['description']}")
+        parts = [str(t["id"]), "[x]" if t.get("done") else "[ ]"]
+        if show_priority:
+            parts.append(str(t.get("priority", "-")))
+        if show_due:
+            parts.append(str(t.get("due", "-")))
+        parts.append(t["description"])
+        print(" ".join(parts))
 
 def mark_done(task_id: int):
     tasks = load_tasks()
@@ -66,6 +88,14 @@ def main():
 
     add_p = subparsers.add_parser("add", help="Add a new task")
     add_p.add_argument("description", help="Task description")
+    add_p.add_argument(
+        "--priority",
+        help="Task priority",
+    )
+    add_p.add_argument(
+        "--due",
+        help="Due date in YYYY-MM-DD format",
+    )
 
     list_p = subparsers.add_parser("list", help="List tasks")
 
@@ -80,7 +110,7 @@ def main():
     args = parser.parse_args()
 
     if args.command == "add":
-        add_task(args.description)
+        add_task(args.description, priority=args.priority, due=args.due)
     elif args.command == "list":
         list_tasks()
     elif args.command == "done":


### PR DESCRIPTION
## Summary
- add `--priority` and `--due` options for `add` command
- store priority and due date in `tasks.json`
- show priority and due date columns when listing tasks
- document new options in README

## Testing
- `python -m py_compile todo.py`
- `python todo.py -h`

------
https://chatgpt.com/codex/tasks/task_e_6841e2df15348324a93c4fb77f9499af