### PR TITLE
Add tests for todo functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ python todo.py clear                # Remove all tasks
 The `add` command accepts optional `--priority` and `--due YYYY-MM-DD` arguments to
 specify a priority level and due date for the task. Tasks are stored in
 `tasks.json` in the same directory.
+
+## Running Tests
+
+Install `pytest` and run the test suite with:
+
+```
+pytest
+```

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -1,0 +1,55 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import os
+import tempfile
+import json
+
+import todo
+
+
+def test_add_task(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tasks_file = os.path.join(tmpdir, "tasks.json")
+        monkeypatch.setattr(todo, "TASKS_FILE", tasks_file)
+
+        todo.add_task("Test task", priority="high", due="2024-01-01")
+
+        with open(tasks_file) as f:
+            tasks = json.load(f)
+
+        assert len(tasks) == 1
+        t = tasks[0]
+        assert t["description"] == "Test task"
+        assert t["priority"] == "high"
+        assert t["due"] == "2024-01-01"
+        assert t["done"] is False
+
+
+def test_mark_done(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tasks_file = os.path.join(tmpdir, "tasks.json")
+        monkeypatch.setattr(todo, "TASKS_FILE", tasks_file)
+
+        todo.add_task("Test task")
+        todo.mark_done(1)
+
+        with open(tasks_file) as f:
+            tasks = json.load(f)
+
+        assert tasks[0]["done"] is True
+
+
+def test_delete_task(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tasks_file = os.path.join(tmpdir, "tasks.json")
+        monkeypatch.setattr(todo, "TASKS_FILE", tasks_file)
+
+        todo.add_task("Test task")
+        todo.delete_task(1)
+
+        if os.path.exists(tasks_file):
+            with open(tasks_file) as f:
+                tasks = json.load(f)
+        else:
+            tasks = []
+
+        assert tasks == []


### PR DESCRIPTION
## Summary
- add `tests/` with new unit tests that use temporary directories
- document how to run the tests using pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e7435de883248c912c16686832d7